### PR TITLE
Increase production flavor log volumes to 120GB

### DIFF
--- a/bootstrap-scripts/production/volume-config.yaml
+++ b/bootstrap-scripts/production/volume-config.yaml
@@ -28,16 +28,16 @@ classes:
       - /dev/xvdb2 /mnt xfs
       - /dev/xvdb1 /var/log/pnda xfs
     partitions:
-      - /dev/xvdb msdos /dev/xvdb1 0GB 10GB
-      - /dev/xvdb msdos /dev/xvdb2 10GB 100%
+      - /dev/xvdb msdos /dev/xvdb1 0GB 120GB
+      - /dev/xvdb msdos /dev/xvdb2 120GB 100%
 
   generic:
     volumes:
       - /dev/xvdb2 /mnt xfs
       - /dev/xvdb1 /var/log/pnda xfs
     partitions:
-      - /dev/xvdb msdos /dev/xvdb1 0GB 10GB
-      - /dev/xvdb msdos /dev/xvdb2 10GB 100%
+      - /dev/xvdb msdos /dev/xvdb1 0GB 120GB
+      - /dev/xvdb msdos /dev/xvdb2 120GB 100%
 
 instances:
   hadoop-dn: datanode


### PR DESCRIPTION
Increase production flavor log volumes to 120GB to match the standard
flavor.

PNDA-3422