### PR TITLE
Make iptables rule setup idempotent

### DIFF
--- a/bootstrap-scripts/package-install.sh
+++ b/bootstrap-scripts/package-install.sh
@@ -11,6 +11,8 @@ cat > /etc/rsyslog.d/10-iptables.conf <<EOF
 STOP
 EOF
 sudo service rsyslog restart
+iptables -F LOGGING | true
+iptables -X LOGGING | true
 iptables -N LOGGING
 iptables -A OUTPUT -j LOGGING
 ## Accept all local scope IP packets.


### PR DESCRIPTION
Allow the bootstrap phase to rerun by clearing any existing iptables
commands before creating them.

PNDA-3431