### PR TITLE
Fix creation of pico/std clusters

### DIFF
--- a/bootstrap-scripts/package-install.sh
+++ b/bootstrap-scripts/package-install.sh
@@ -36,20 +36,26 @@ chmod +x /etc/rc.d/rc.local | true
 fi
 
 DISTRO=$(cat /etc/*-release|grep ^ID\=|awk -F\= {'print $2'}|sed s/\"//g)
+
 if [ "x$DISTRO" == "xubuntu" ]; then
   export DEBIAN_FRONTEND=noninteractive
-  # give the local mirror the first priority
-  sed -i "1ideb $PNDA_MIRROR/mirror_deb/ ./" /etc/apt/sources.list
   wget -O - $PNDA_MIRROR/mirror_deb/pnda.gpg.key | apt-key add -
 
 if [ "x$ADD_ONLINE_REPOS" == "xYES" ]; then
-  (curl -L 'https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/archive.key' | apt-key add - ) && echo 'deb [arch=amd64] https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/ trusty-cm5.9.0 contrib' > /etc/apt/sources.list.d/cloudera-manager.list
-  (curl -L 'http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub' | apt-key add - ) && echo 'deb [arch=amd64] http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/ trusty main' > /etc/apt/sources.list.d/saltstack.list
-  (curl -L 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add - ) && echo 'deb [arch=amd64] https://deb.nodesource.com/node_6.x trusty main' > /etc/apt/sources.list.d/nodesource.list
-fi
-  apt-get update
+  # Give local mirror priority
+  sed -i "1ideb $PNDA_MIRROR/mirror_deb/ ./" /etc/apt/sources.list
 
-elif [ "x$DISTRO" == "xrhel"  -o "x$DISTRO" == "xcentos" ]; then
+  (curl -L 'https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/archive.key' | apt-key add - ) && echo 'deb [arch=amd64] https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/ trusty-cm5.9.0 contrib' > /etc/apt/sources.list.d/cloudera-manager.list
+  (curl -L 'https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub' | apt-key add - ) && echo 'deb [arch=amd64] https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/ trusty main' > /etc/apt/sources.list.d/saltstack.list
+  (curl -L 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add - ) && echo 'deb [arch=amd64] https://deb.nodesource.com/node_6.x trusty main' > /etc/apt/sources.list.d/nodesource.list
+else
+  mv /etc/apt/sources.list /etc/apt/sources.list.backup
+  echo -e "deb $PNDA_MIRROR/mirror_deb/ ./" > /etc/apt/sources.list
+fi
+
+apt-get update
+
+elif [ "x$DISTRO" == "xrhel" -o "x$DISTRO" == "xcentos" ]; then
 
 if [ "x$ADD_ONLINE_REPOS" == "xYES" ]; then
   RPM_EXTRAS=rhui-REGION-rhel-server-extras

--- a/bootstrap-scripts/volume-mappings.sh
+++ b/bootstrap-scripts/volume-mappings.sh
@@ -24,11 +24,13 @@ print '\nrequested volumes:'
 print requested_volumes
 
 # Find out what volumes are available
-out = subprocess.check_output(['lsblk', '-branp', '-o', 'NAME,SIZE,MOUNTPOINT'])
+out = subprocess.check_output(['lsblk', '-brn', '-o', 'NAME,SIZE,MOUNTPOINT'])
 available_volumes = []
 for line in out.splitlines():
-   fields = line.split(' ')
-   available_volumes.append(fields)
+    fields = line.split(' ')
+    if len(fields) > 0:
+      fields[0] = "/dev/%s" % fields[0]
+      available_volumes.append(fields)
 
 # Sort by size and name
 available_volumes.sort(key=lambda x: (-int(x[1]), x[2]))

--- a/cli/pnda-cli.py
+++ b/cli/pnda-cli.py
@@ -461,14 +461,7 @@ def create(template_data, cluster, flavor, keyname, no_config_check, dry_run, br
             cf_parameters.append((parameter, PNDA_ENV['cloud_formation_parameters'][parameter]))
 
         if not no_config_check:
-            if existing_machines_def_file is None:
-                check_aws_connection()
-            check_keypair(keyname, keyfile, existing_machines_def_file)
-            check_package_server()
-            check_java_mirror()
-
-        if not no_config_check:
-            check_config(keyname, keyfile, existing_machines_def_file)
+            check_config(keyname, keyfile, None)
 
         save_cf_resources('create_%s' % MILLI_TIME(), cluster, cf_parameters, template_data)
         if dry_run:


### PR DESCRIPTION
This is a variety of fix ups needed for the creation of 'normal' PNDA clusters
in AWS, whilst retaining the ability to create PNDA on server clusters. 
Following this point, the intention is to deprecate pnda-aws-templates. 

Tested pico/std/prod on rhel/ubuntu with hdp/cdh, but not every combination thereof.