### PR TITLE
PNDA-3299 : Support multiple NTP servers properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3218: Add iprejecter to enable offline env
 - PNDA-3314: Add new flavor 'production' designed for larger, bare metal clusters
 - PNDA-3484: Add CentOS support
+- PNDA-3299: Support multiple NTP servers properly
 
 ### Changed
 - PNDA-3186: Refactored code into CLI for creating PNDAs on many platforms (pnda-cli)

--- a/bootstrap-scripts/package-install.sh
+++ b/bootstrap-scripts/package-install.sh
@@ -26,6 +26,7 @@ if [ "x$CLIENT_IP" != "x" ]; then
 iptables -A LOGGING -d  $CLIENT_IP/32 -j ACCEPT # PNDA client
 fi
 if [ "x$NTP_SERVERS" != "x" ]; then
+NTP_SERVERS=$(echo "$NTP_SERVERS" | sed -e 's|[]"'\''\[ ]||g')
 iptables -A LOGGING -d  $NTP_SERVERS -j ACCEPT # NTP server
 fi
 iptables -A LOGGING -d  ${vpcCidr} -j ACCEPT # PNDA network

--- a/bootstrap-scripts/saltmaster-common.sh
+++ b/bootstrap-scripts/saltmaster-common.sh
@@ -146,7 +146,7 @@ if [ "x$NTP_SERVERS" != "x" ] ; then
 cat << EOF >> /srv/salt/platform-salt/pillar/env_parameters.sls
 ntp:
   servers:
-    - "$NTP_SERVERS"
+    "$NTP_SERVERS"
 EOF
 fi
 

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -111,16 +111,14 @@ ntp:
   # Optional ntp servers. Use this if the standard NTP servers on the Internet cannot be reached
   # and a local NTP server has been configured. PNDA will not work without NTP.
   # example format: 'xxx.ntp.org'
-  NTP_SERVERS: ''
+  #For REJECT_OUTBOUND="YES" then NTP server/s must.
+  NTP_SERVERS:
+    - ntp.ubuntu.com
+  # - 91.189.89.199
 
 mirrors:
   # Mirror of resources required for provisioning PNDA, see PNDA guide for instructions on how to set this up
   PNDA_MIRROR: http://x.x.x.x
-
-ntp:
-  # Optional ntp servers. Use this if the standard Ubuntu NTP servers on the Internet cannot be reached
-  # and a local NTP server has been configured. PNDA will not work without NTP.
-  NTP_SERVERS: ''
 
 hadoop:
   # Hadoop distribution to install
@@ -147,11 +145,11 @@ elk-cluster:
 
 connectivity:
   # Deploy an iptables ruleset to every node preventing outbound access to all hosts except the PNDA_MIRROR, NTP_SERVER and specified CLIENT_IP. Specify YES to enable.
-  REJECT_OUTBOUND: YES
+  REJECT_OUTBOUND: "YES"
   # If using REJECT_OUTBOUND, the IP address of the client that created PNDA
   CLIENT_IP: 1.1.1.1
   # Add online repositories for yum, apt-get, pip, etc alongside PNDA mirror
-  ADD_ONLINE_REPOS: NO
+  ADD_ONLINE_REPOS: "NO"
 
 mine_functions:
   MINE_FUNCTIONS_NETWORK_IP_ADDRS_NIC: eth0


### PR DESCRIPTION
Understanding the Requirements:
======================
PNDA-3299
    Add multiple NTP servers as list in the pnda_env.yaml file. This is must for offline deployment.
 
Analysis
    Right now the single NTP server from pnda_env.yaml is supported. For REJECT_OUTBOUND : "NO" no need any NTP servers, since the ntp.conf by default having public NTP servers and which is reachable.  For REJECT_OUTBOUND : "YES", due to blocking of public internet through IPTABLES, NTP servers can't be reached. 

Solution
    REJECT_OUTBOUD : "YES" : Pass NTP servers in pnda_env.yaml file. Getting these list allow in servers by configuring IPTABLES in PNDA instances.
    REJECT_OUTBOUD : "NO"  : No need any configuration, instances can reach default public NTP servers. 

File modified
    pnda_env_example : Adding NTP_SERVERS key entery for NTP list
    bootstrap-scripts/package-install.sh : Adidng NTP servers in IPTABLES
    bootstrap-scripts/saltmaster-common.sh : Modify the code to accept list of NTP servers.
    
Testcase
    1. RHEL offline PICO with multiple (3) internal NTP servers. Validated by shuting down one and then 2 NTP servers.
    2. RHEL offline Standard with multiple (3) internal and one public ntp.ubuntu.com NTP servers
    3. Ubuntu offline PICO with multiple (3) internal NTP servers. Validated by shuting down one and then 2 NTP servers.
    4. Ubuntu offline Standard with multiple (3) internal and one public ntp.ubuntu.com NTP servers
    5. Ubuntu offline pico with out any NTP server in yaml file. Expected NTP sycn failure in PNDA nodes. This is to make sure exiting functionalty is not breaks any thing.
    6. RHEL online pico with out any NTP server in YAML file.

