### PR TITLE
Remove extra node connectivity check after salt

### DIFF
--- a/cli/pnda-cli.py
+++ b/cli/pnda-cli.py
@@ -562,8 +562,6 @@ def create(template_data, cluster, flavor, keyname, no_config_check, dry_run, br
     ssh(['(sudo salt -v --log-level=debug --timeout=120 --state-output=mixed "*" state.highstate queue=True 2>&1) | tee -a pnda-salt.log; %s' % THROW_BASH_ERROR,
          '(sudo CLUSTER=%s salt-run --log-level=debug state.orchestrate orchestrate.pnda 2>&1) | tee -a pnda-salt.log; %s' % (cluster, THROW_BASH_ERROR),
          '(sudo salt "*%s" state.sls hostsfile 2>&1) | tee -a pnda-salt.log; %s' % (bastion, THROW_BASH_ERROR)], cluster, saltmaster_ip)
-    time.sleep(60)
-    wait_for_host_connectivity([instance_map[h]['private_ip_address'] for h in instance_map], cluster)
     
     return instance_map[cluster + '-' + NODE_CONFIG['console-instance']]['private_ip_address']
 
@@ -651,8 +649,6 @@ def expand(template_data, cluster, flavor, old_datanodes, old_kafka, include_orc
 
     ssh(expand_commands, cluster, saltmaster_ip)
     CONSOLE.info("Nodes may reboot due to kernel upgrade, wait for few minutes")
-    time.sleep(60)
-    wait_for_host_connectivity([instance_map[h]['private_ip_address'] for h in instance_map], cluster)
 
     return instance_map[cluster + '-' + NODE_CONFIG['console-instance']]['private_ip_address']
 


### PR DESCRIPTION
This is not needed now the nodes are no longer rebooted automatically.
PNDA-3524