### PR TITLE
Creation time improvements for large clusters when there is no bastion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Fixed
 - PNDA-3534: Make iptables injection script idempotent.
+- PNDA-3552: Creation time improvements for large clusters when there is no bastion.
 
 ## [1.0.0] 2017-11-24
 ### Added

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -7,7 +7,7 @@ ec2_access:
   # AWS region to create PNDA ec2 instances in
   AWS_REGION: eu-west-1
   AWS_AVAILABILITY_ZONE: eu-west-1a
-  
+
   # The user name to use when logging into the AWS ec2 instances
   # Ubuntu: ubuntu
   # Redhat: ec2-user
@@ -19,7 +19,7 @@ cloud_formation_parameters:
   # creating the cloud formation template. The cloud formation template must
   # define a matching input parameter for each value listed here.
 
-  # Base image to use, use the default AWS Ubuntu/Redhat image for the AWS region 
+  # Base image to use, use the default AWS Ubuntu/Redhat image for the AWS region
   # Ubuntu: 64-bit Ubuntu 14.04
   # Redhat: Red Hat Enterprise Linux 7
   imageId: ami-f95ef58a
@@ -68,7 +68,7 @@ pnda_application_repo:
   #   local  - local filesystem on the package repository service server. Also set PR_FS_LOCATION_PATH.
   PR_FS_TYPE: s3
 
-  # S3 container to use for PNDA application packages 
+  # S3 container to use for PNDA application packages
   PNDA_APPS_CONTAINER: pnda-apps
 
   # Name of folder within PNDA_APPS_CONTAINER that contains the PNDA application packages
@@ -84,8 +84,8 @@ pnda_application_repo:
 
   # Path on file system if PR_FS_TYPE is 'local' or 'sshfs'
   PR_FS_LOCATION_PATH: /opt/pnda/packages
-    
-  # SSH accessed file system to use for PNDA application packages 
+
+  # SSH accessed file system to use for PNDA application packages
   PR_SSHFS_USER: ubuntu
   PR_SSHFS_HOST: 127.0.0.1
   PR_SSHFS_PATH: /mnt/packages
@@ -151,7 +151,13 @@ connectivity:
 
 mine_functions:
   MINE_FUNCTIONS_NETWORK_IP_ADDRS_NIC: eth0
-  
+
 network_interfaces:
   PNDA_INTERNAL_NETWORK: eth0
   PNDA_INGEST_NETWORK: eth1
+
+cli:
+  # Maximum number of outbound connections that the CLI will attempt to open at once
+  # Consider increasing this when creating clusters with more than 100 nodes to speed
+  # up PNDA creation time.
+  MAX_SIMULATANEOUS_OUTBOUND_CONNECTIONS: 100


### PR DESCRIPTION
Run host operations simultaneously. The number of operations to execute
simultaneously is  controlled by a new pnda-env.yaml config
`cli:MAX_SIMULATANEOUS_OUTBOUND_CONNECTIONS`. This setting is defaulted
to 100, if a cluster with more than 100 nodes is being created the
operator can increase this at their discretion.

When there is a bastion, continue to wait 2 seconds between starting
each operation so the bastion does not get overloaded with inbound
connections.

This means the effective wait time when using a bastion still scales
with the number of nodes (number of nodes*4 seconds) and when not using
a bastion it does not increase with the number of nodes assuming
MAX_SIMULATANEOUS_OUTBOUND_CONNECTIONS can be set higher than the
number of nodes in the cluster. If it cannot be set higher then the time will scale with the number of batches the operations must be run in to keep the number of connections below this figure.

PNDA-3553