### PR TITLE
Fix for missing missing /etc/cloud directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.idea
 *.log
 *.pem
 *.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3199: Make socks proxy script executable
 - PNDA-3424: Add a retry to AWS API calls to work around SSL timeout errors
 - PNDA-3377: fix issue on check config which required descriptor file
+- Fork: Fixed issue with missing /etc/cloud directory failing install on baremetal
 
 ## [FORK]
 - Applied annotation tag where pndaproject/pnda-aws-templates has been forked.

--- a/bootstrap-scripts/base.sh
+++ b/bootstrap-scripts/base.sh
@@ -37,9 +37,11 @@ pnda_cluster: $PNDA_CLUSTER
 EOF
 
 if [ "x$DISTRO" == "xrhel"  -o "x$DISTRO" == "xcentos" ]; then
-cat >> /etc/cloud/cloud.cfg <<EOF
-preserve_hostname: true
-EOF
+    if [ -D "/etc/cloud/" ]; then
+    cat >> /etc/cloud/cloud.cfg <<EOF
+    preserve_hostname: true
+    EOF
+    fi
 fi
 
 /tmp/volume-mappings.sh /etc/pnda/disk-config/requested-volumes /etc/pnda/disk-config/volume-mappings

--- a/bootstrap-scripts/base.sh
+++ b/bootstrap-scripts/base.sh
@@ -37,11 +37,11 @@ pnda_cluster: $PNDA_CLUSTER
 EOF
 
 if [ "x$DISTRO" == "xrhel"  -o "x$DISTRO" == "xcentos" ]; then
-    if [ -D "/etc/cloud/" ]; then
-    cat >> /etc/cloud/cloud.cfg <<EOF
-    preserve_hostname: true
-    EOF
-    fi
+if [ -d "/etc/cloud" ]; then
+cat >> /etc/cloud/cloud.cfg <<EOF
+preserve_hostname: true
+EOF
+fi
 fi
 
 /tmp/volume-mappings.sh /etc/pnda/disk-config/requested-volumes /etc/pnda/disk-config/volume-mappings


### PR DESCRIPTION
In baremetal deployments where cloud init scripts are not used /etc/cloud does not exist so we cannot create a file in said directory.