### PR TITLE
Update boto requirement to 2.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3365: remove unnecessary explicit hostfile setup on bastion
 - PNDA-3530: Ambari version 2.6.0.0 and HDP version 2.6.3.0
 - PNDA-3487: /tmp is now tmpfs for production
+- PNDA-3602: Update boto requirement to 2.48.0 for updated ec2 region support
 
 ### Fixed
 - PNDA-3534: Make iptables injection script idempotent.

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,3 +1,3 @@
-boto==2.40.0
+boto==2.48.0
 PyYAML==3.11
 requests==2.11.1


### PR DESCRIPTION
Update boto requirement to 2.48.0 for updated ec2 region support
PNDA-3602