### PR TITLE
PNDA-3127: Post ingress aggregation for Kafka datasets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- PNDA-3127: PNDA-3127: Post ingress aggregation for Kafka datasets
 - PNDA-3299: Support multiple NTP servers properly
 - PNDA-3599: Console output indicating any cloud formation stack errors
 - PNDA-3598: Add a pre-check to validate the AWS region

--- a/bootstrap-scripts/saltmaster-common.sh
+++ b/bootstrap-scripts/saltmaster-common.sh
@@ -179,3 +179,17 @@ features:
   - EXPERIMENTAL
 EOF
 fi
+
+if [ "$COMPACTION" == "YES" ] ; then
+cat << EOF >> /srv/salt/platform-salt/pillar/env_parameters.sls
+dataset_compaction:
+  compaction: $COMPACTION
+  pattern: '$PATTERN'
+EOF
+else
+cat << EOF >> /srv/salt/platform-salt/pillar/env_parameters.sls
+dataset_compaction:
+  compaction: NO
+  pattern: '$PATTERN'
+EOF
+fi

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -165,3 +165,14 @@ features:
   # Set to "NO", omit setting or omit features section entirely to turn off experimental features
   EXPERIMENTAL_FEATURES: "NO"
 
+dataset_compaction:
+  # Enable/Disable compaction on datasets.
+  # "YES" to enable.
+  # "NO" to disable.
+  COMPACTION: "NO"
+  # If compaction is enabled, PATTERN sets the frequency of compaction.
+  # H - hourly compaction.
+  # d - daily compaction.
+  # M - monthly compaction.
+  # Y - yearly compaction.
+  PATTERN: d


### PR DESCRIPTION
1. Gobblin Compaction-

*******************
1.1. Brief
--Compaction strategy will be set at deployment level
--If compaction is enabled, compacted datasets will be stored in - /user/pnda/PNDA_datasets/compacted/ directory
--Compaction strategy will apply to all the datasets (system wide)
--User at the time of deployment will be able to control following parameters w.r.t. compaction
---Enable/Disable compaction
---Level of compaction <Hourly(H), Daily(d), Monthly(M), Yearly(Y)>

**Note: when the datasets would appear in compacted dataset (/user/pnda/PNDA_datasets/compacted) will depend on the level of compaction. For instance in case of hourly compaction  it will appear 
after a lag of 2 hours from the time it was pulled into staging directory, for daily compaction after a lag 1 day and so on.


1.2. At deployment level, using pnda-cli/pnda_env.yaml user can enable/disable compaction, defaults to disable. Compaction properties will apply system wide and not per dataset. 

pnda-cli/pnda_env.yaml

dataset_compaction:
    compaction: "YES"
    level: H
    
1.2.1 Parameters-

compaction - To enable/disable compaction: "YES"/"NO"
level - To set compaction strategy: H - hourly, d - daily, M - monthly, Y - yearly

1.3. Compaction behavior
Case: 1.3.1. compaction is set to "NO"
--No compaction will be performed 
--Pull job will submit data to /user/pnda/PNDA_datasets/datasets/

Case: 1.3.2. compaction is "YES"
--compaction will be performed 
--Pull job will submit data to /user/pnda/PNDA_datasets/sdatasets/
--compaction job will run on datasets directory. compacted data will be stored in /user/pnda/PNDA_datasets/compacted/

Case: 1.3.2.1. level: H
--Compaction job will run every hour
--Will compact data not older than 1 day and which is not being generated in past 1 hour

Case: 1.3.2.1.2. level: d
--Compaction job will run once a day
--Will compact data not older than 1 day and which is not being generated in past 1 hour

Case: 1.3.2.1.3. level: M
--Compaction job will run once a month
--Will compact data not older than 1 month and which is not being generated in past 1 hour

Case: 1.3.2.1.4. level: Y
--Compaction job will run once a year
--Will compact data not older than 1 year and which is not being generated in past 1 hour

**********************
3. Cron configuration

Case: 3.1. level: H
0 * * * * 	

Case: 3.2. level: d
0 1 * * * 	

Case: 3.3. level: M
0 1 1 * * 	

Case: 3.4. level: Y
0 1 1 1 *  

**********************
PNDA-3127 has dependency upon PNDA-3133