### PR TITLE
Allow void arguments for specific invocation combinations

### DIFF
--- a/cli/pnda-cli.py
+++ b/cli/pnda-cli.py
@@ -868,6 +868,12 @@ def main():
     if fields['command'] == 'expand':
         node_counts = get_current_node_counts(fields['pnda_cluster'], fields['x_machines_definition'])
 
+        # if these fields not supplied, default to previous values
+        if fields['datanodes'] is None:
+            fields['datanodes'] = node_counts['hadoop-dn']
+        if fields['kafka_nodes'] is None:
+            fields['kafka_nodes'] = node_counts['kafka']
+
         if fields['datanodes'] < node_counts['hadoop-dn']:
             print "You cannot shrink the cluster using this CLI, existing number of datanodes is: %s" % node_counts['hadoop-dn']
             sys.exit(1)


### PR DESCRIPTION
Addresses two bugs by introducing a mechanism to assign arbitrary predicates to fields, and using that to mark several fields as not requiring prompting in certain argument combinations.
PNDA-3629: Expand command requires input for all nodes, even if only one or two are to be scaled
PNDA-3627: When creating PNDA on server clusters, prompted for how many nodes to create even though this is already specified in JSON
