### PR TITLE
PNDA-3623: Add support for configuring Jupyter with SSL cert/key.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3598: Add a pre-check to validate the AWS region
 - PNDA-3511: Export a bundle of resources used during provisioning to `cli/logs/<cluster>_<time>_bootstrap-resources.tar.gz` to help an operator with later operations tasks such as a recreating a failed node.
 - PNDA-3630: Added EXPERIMENTAL flag to pnda_env.yaml which is initially only used to include Jupyter Scala support
+- PNDA-3623: Add support for configuring Jupyter with SSL cert/key.
 
 ### Changed
 - PNDA-3583: hadoop distro is now part of grains

--- a/platform-certificates/jupyter/README.md
+++ b/platform-certificates/jupyter/README.md
@@ -1,0 +1,6 @@
+Security material put in this directory can be used to configure jupyter.
+It should either be left empty to have jupyterhub accessible through http.
+Or it should include the private key and associated certificate chain needed to configure jupyterhub for SSL (https).
+In the later case, it should contain:
+1. A file with a .pem extension and content in PEM format (Privacy-enhanced Electronic Mail): Base64 encoded DER certificate chain (concatenation) with each certificate enclosed between "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----"
+2. A file with a .key extension and content in PEM format (Privacy-enhanced Electronic Mail): Base64 encoded DER key enclosed between "-----BEGIN ENCRYPTED PRIVATE KEY-----" and "-----END ENCRYPTED PRIVATE KEY-----"

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -160,6 +160,19 @@ cli:
   # up PNDA creation time.
   MAX_SIMULTANEOUS_OUTBOUND_CONNECTIONS: 100
 
+security:
+  # The security mode to be enforced. Options are:
+  # - 'disabled': The security material will be ignored.  
+  # - 'permissive': The security material will be used if present.
+  # - 'enforced': The security material will be required to be present and conforment to the associated requirements.
+  SECURITY_MODE: 'permissive'
+
+  # The path were to find the security material (certificate/key).
+  # The directory should be structured as defined in this' repo's directory structure with the same name.
+  # If present, the security material should conform to the guidelines defined in the README.md file in
+  # the containing sub dorectory.
+  SECURITY_MATERIAL_PATH: ./platform-certificates/
+
 features:
   # Include experimental features. 
   # Set to "NO", omit setting or omit features section entirely to turn off experimental features


### PR DESCRIPTION
The security material should be placed in the
platform-certificates/jupyter/ directory and should comply to the
requirements defined in the platform-certificates/jupyter/README.md
file.
The key will be placed in a pillar accessible to the node with a role
the same name as the subdirectory the key is stored in (Jupyter in this
case).
The certificate will be placed in a shared pillar as that content is not
secret and needs to be accessible to other roles (example: the console
frontend needs to be configured with the CN defined in the certificate
to allow SSL server validation.