### PR TITLE
Add option to sink Spark Metrics

### DIFF
--- a/bootstrap-scripts/saltmaster-common.sh
+++ b/bootstrap-scripts/saltmaster-common.sh
@@ -143,6 +143,10 @@ pnda.archive_container: '$PNDA_ARCHIVE_CONTAINER'
 pnda.archive_type: 's3a'
 pnda.archive_service: ''
 
+spark_metrics:
+  spark_metrics_sink_ip: '$SPARK_METRICS_SINK_IP'
+  spark_metrics_port: '$SPARK_METRICS_PORT'
+
 pnda_mirror:
   base_url: '$PNDA_MIRROR'
   misc_packages_path: /mirror_misc/

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -123,6 +123,15 @@ hadoop:
   # - CDH
   HADOOP_DISTRO: CDH
 
+spark_metrics:
+  # Optional SPARK_METRICS_SINK_IP. 
+  # By default PNDA cluster is configured to sink Spark Metrics to Graphite DB in edge node.
+  # Optionally Users can specify this sink to be to an external server accessible to PNDA cluster.
+  SPARK_METRICS_SINK_IP: ''
+  # Spark Metrics sink will use this Port number to send metrics data
+  # port number is ignored, if SPARK_METRICS_SINK_IP is omitted and will use port 2003
+  SPARK_METRICS_PORT: 2003
+
 elk-cluster:
   # number of master nodes
   MASTER_NODES: 0


### PR DESCRIPTION
PNDA-4043: Add option to sink Spark Metrics to an external Graphite DB

Currently, PNDA cluster default configuration  sink Spark Metrics to Graphite DB, residing in PNDA cluster. Introduce an option which allows users to configure the sink to an external Graphite DB.  User provides the external host name / IP Address and port number in pnda_env_example.yaml (SPARK_METRICS_SINK_IP , SPARK_METRICS_PORT).  Internal Graphite sink is used by default, if external sink is not provide by user.

Verified the fix for AWS:
UBUNTU - PICO -CDH & HDP
UBUNTU - STD -CDH & HDP
RHEL - PICO -CDH & HDP
RHEL - STD -CDH & HDP
