### PR TITLE
Use a separate partition for logs on the Jupyter node.

### DIFF
--- a/bootstrap-scripts/standard/volume-config.yaml
+++ b/bootstrap-scripts/standard/volume-config.yaml
@@ -13,7 +13,7 @@ classes:
 instances:
   hadoop-dn: datanode
   bastion: no_additonal_volumes
-  jupyter: no_additonal_volumes
+  jupyter: generic
   saltmaster: no_additonal_volumes
   tools: no_additonal_volumes
   kafka: generic

--- a/cloud-formation/standard/cf-flavor.json
+++ b/cloud-formation/standard/cf-flavor.json
@@ -330,6 +330,10 @@
           {
               "DeviceName" : "/dev/sda1",
               "Ebs" : { "VolumeSize" : "50" }
+          },
+          {
+              "DeviceName" : "/dev/sdc",
+              "Ebs" : { "VolumeSize" : {"Ref": "logVolumeSizeGb"} }
           }
         ],
         "SecurityGroupIds": [ {"Ref": "pndaSg"} ]


### PR DESCRIPTION
PNDA-4052:
As separate volume is now used for the logs on the Jupyter node as is
done for other nodes that requires a log partition.

