### PR TITLE
Apply timeouts in thread.join

### DIFF
--- a/cli/pnda-cli.py
+++ b/cli/pnda-cli.py
@@ -137,6 +137,8 @@ def main():
     ###
     input_validator = UserInputValidator(valid_flavors())
     fields = input_validator.parse_user_input()
+    if fields['verbose']:
+        utils.set_log_level('DEBUG')
     utils.init_runfile(fields['pnda_cluster'])
 
     os.chdir('../')
@@ -207,16 +209,16 @@ def main():
             fields['kafka_nodes'] = node_counts['kafka']
 
         if fields['datanodes'] < node_counts['hadoop-dn']:
-            print "You cannot shrink the cluster using this CLI, existing number of datanodes is: %s" % node_counts['hadoop-dn']
+            CONSOLE.INFO("You cannot shrink the cluster using this CLI, existing number of datanodes is: %s", node_counts['hadoop-dn'])
             sys.exit(1)
         elif fields['datanodes'] > node_counts['hadoop-dn']:
-            print "Increasing the number of datanodes from %s to %s" % (node_counts['hadoop-dn'], fields['datanodes'])
+            CONSOLE.INFO("Increasing the number of datanodes from %s to %s", node_counts['hadoop-dn'], fields['datanodes'])
             do_orchestrate = True
         if fields['kafka_nodes'] < node_counts['kafka']:
-            print "You cannot shrink the cluster using this CLI, existing number of kafkanodes is: %s" % node_counts['kafka']
+            CONSOLE.INFO("You cannot shrink the cluster using this CLI, existing number of kafkanodes is: %s", node_counts['kafka'])
             sys.exit(1)
         elif fields['kafka_nodes'] > node_counts['kafka']:
-            print "Increasing the number of kafkanodes from %s to %s" % (node_counts['kafka'], fields['kafka_nodes'])
+            CONSOLE.INFO("Increasing the number of kafkanodes from %s to %s", node_counts['kafka'], fields['kafka_nodes'])
 
         # Does not support changing the following during an expand
         fields['opentsdb_nodes'] = node_counts['opentsdb']

--- a/cli/pnda_cli_utils.py
+++ b/cli/pnda_cli_utils.py
@@ -45,6 +45,10 @@ LOG_FILE_NAME = None
 CONSOLE_LOGGER = None
 FILE_LOGGER = None
 
+def set_log_level(log_level):
+    CONSOLE_LOGGER.setLevel(logging.getLevelName(log_level))
+    FILE_LOGGER.setLevel(logging.getLevelName(log_level))
+
 def init_logging():
     global LOG_FILE_NAME
     global CONSOLE_LOGGER

--- a/cli/validation.py
+++ b/cli/validation.py
@@ -293,7 +293,9 @@ class UserInputValidator(object):
         parser.add_argument('-m', '--x-machines-definition',
                             help=('File describing topology of target server cluster. If specified, '
                                   'topology specifiers -k, -z, -o and -n are not required.'))
-
+        parser.add_argument('-v', '--verbose',
+                            help='Verbose logging',
+                            action='store_true')
         args = parser.parse_args()
 
         return args


### PR DESCRIPTION
Apply a 10 minute timeout in thread.join rather than relying on an individual thread to timeout and report failure when running commands against minions.

This avoids the case where the CLI calls out to ssh when checking connectivity and it never returns.

This timeout is now applied to all ssh commands on minions (except for the main install of PNDA) and not just the initial connectivity check.

Also added a verbose option -v to the pnda-cli. Setting this sets the logging to debug, defaults to info otherise as is currently the case.

PNDA-4453