### PR TITLE
Use wget instead of curl with apt-key

### DIFF
--- a/bootstrap-scripts/package-install.sh
+++ b/bootstrap-scripts/package-install.sh
@@ -47,10 +47,9 @@ if [ "x$DISTRO" == "xubuntu" ]; then
 if [ "x$ADD_ONLINE_REPOS" == "xYES" ]; then
   # Give local mirror priority
   sed -i "1ideb $PNDA_MIRROR/mirror_deb/ ./" /etc/apt/sources.list
-  apt-get -y install curl
-  (curl -L 'https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/archive.key' | apt-key add - ) && echo 'deb [arch=amd64] https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/ trusty-cm5.9.0 contrib' > /etc/apt/sources.list.d/cloudera-manager.list
-  (curl -L 'https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub' | apt-key add - ) && echo 'deb [arch=amd64] https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/ trusty main' > /etc/apt/sources.list.d/saltstack.list
-  (curl -L 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add - ) && echo 'deb [arch=amd64] https://deb.nodesource.com/node_6.x trusty main' > /etc/apt/sources.list.d/nodesource.list
+  (wget -O - 'https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/archive.key' | apt-key add - ) && echo 'deb [arch=amd64] https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/ trusty-cm5.9.0 contrib' > /etc/apt/sources.list.d/cloudera-manager.list
+  (wget -O - 'https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub' | apt-key add - ) && echo 'deb [arch=amd64] https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/ trusty main' > /etc/apt/sources.list.d/saltstack.list
+  (wget -O - 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add - ) && echo 'deb [arch=amd64] https://deb.nodesource.com/node_6.x trusty main' > /etc/apt/sources.list.d/nodesource.list
 else
   mv /etc/apt/sources.list /etc/apt/sources.list.backup
   echo -e "deb $PNDA_MIRROR/mirror_deb/ ./" > /etc/apt/sources.list


### PR DESCRIPTION
This avoids having to install curl on ubuntu before configuring the PNDA mirror as the source of deb packages.

PNDA-4498