### PR TITLE
Add setting to choose Spark version for Oozie

### DIFF
--- a/bootstrap-scripts/saltmaster-common.sh
+++ b/bootstrap-scripts/saltmaster-common.sh
@@ -144,6 +144,7 @@ packages_server:
 hdp:
   hdp_core_stack_repo: '$PNDA_MIRROR/mirror_hdp/HDP/$HDP_OS/2.6.4.0-91/'
   hdp_utils_stack_repo: '$PNDA_MIRROR/mirror_hdp/HDP-UTILS-1.1.0.22/repos/$HDP_OS/'
+  oozie_spark_version: '$OOZIE_SPARK_VERSION'
 
 mine_functions:
   network.ip_addrs: [$PNDA_INTERNAL_NETWORK]

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -181,6 +181,11 @@ hadoop:
   # - HDP
   # - CDH
   HADOOP_DISTRO: HDP
+  # Spark version to enable for oozie (HDP only)
+  # Valid values are:
+  # - 1
+  # - 2
+  OOZIE_SPARK_VERSION: 1
 
 connectivity:
   # Deploy an iptables ruleset to every node preventing outbound access to all hosts except the PNDA_MIRROR, NTP_SERVER and specified CLIENT_IP. Specify YES to enable.


### PR DESCRIPTION
Add setting to choose Spark version for Oozie. Defaults to 1 to keep Spark 1 by default as the Spark 2 technical preview is not production ready according to Hortonworks.

PNDA-4398