### PR TITLE
Removed "extra-index-url" and "find_links" directives from pip and easy_install configurations.

### DIFF
--- a/bootstrap-scripts/package-install.sh
+++ b/bootstrap-scripts/package-install.sh
@@ -90,13 +90,3 @@ cat << EOF > /root/.pydistutils.cfg
 [easy_install]
 index_url=$PIP_INDEX_URL
 EOF
-
-if [ "x$ADD_ONLINE_REPOS" == "xYES" ]; then
-cat << EOF >> /etc/pip.conf
-extra-index-url=https://pypi.python.org/simple/
-EOF
-cat << EOF >> /root/.pydistutils.cfg
-find_links=https://pypi.python.org/simple/
-EOF
-fi
-


### PR DESCRIPTION
As these directives result in an unwanted upgrade and broken python packages sub-dependencies, when "ADD_ONLINE_REPOS" flag is set to "Yes"

PNDA-4441