### PR TITLE
PNDA-4075 : Number of data volumes to be configurable in pnda_env.yam…

### DIFF
--- a/bootstrap-scripts/pico/volume-config.yaml
+++ b/bootstrap-scripts/pico/volume-config.yaml
@@ -1,7 +1,13 @@
 classes:
   datanode:
     volumes:
-      - /data0 xfs
+{%- for n in range(pnda_env['datanode']['DATA_VOLUME_COUNT']) %}
+    {%- if pnda_env['datanode']['DATA_VOLUME_COUNT'] > 10 and n < 10 %}
+      - /data0{{ n }} xfs
+    {%- else %}
+      - /data{{ n }} xfs
+    {%- endif %}
+{%- endfor %}
       - /var/log/pnda xfs
 
   no_additonal_volumes:

--- a/bootstrap-scripts/production/volume-config.yaml
+++ b/bootstrap-scripts/production/volume-config.yaml
@@ -1,36 +1,19 @@
 classes:
   datanode:
     volumes:
-      - /data00 xfs
-      - /data01 xfs
-      - /data02 xfs
-      - /data03 xfs
-      - /data04 xfs
-      - /data05 xfs
-      - /data06 xfs
-      - /data07 xfs
-      - /data08 xfs
-      - /data09 xfs
-      - /data10 xfs
-      - /data11 xfs
-      - /data12 xfs
-      - /data13 xfs
-      - /data14 xfs
-      - /data15 xfs
-      - /data16 xfs
-      - /data17 xfs
-      - /data18 xfs
-      - /data19 xfs
-      - /data20 xfs
-      - /data21 xfs
-      - /data22 xfs
-      - /data23 xfs
-      - /dev/xvdb2 /mnt xfs
-      - /dev/xvdb1 /var/log/pnda xfs
+{%- for n in range(pnda_env['datanode']['DATA_VOLUME_COUNT']) %}
+    {%- if pnda_env['datanode']['DATA_VOLUME_COUNT'] > 10 and n < 10 %}
+      - /data0{{ n }} xfs
+    {%- else %}
+      - /data{{ n }} xfs
+    {%- endif %}
+{%- endfor %}
+      - /dev/{{ pnda_env['datanode']['DEVICE_ROOT'] }}2 /mnt xfs
+      - /dev/{{ pnda_env['datanode']['DEVICE_ROOT'] }}1 /var/log/pnda xfs
       - tmpfs /tmp tmpfs nodev,nosuid
     partitions:
-      - /dev/xvdb msdos /dev/xvdb1 0GB 120GB
-      - /dev/xvdb msdos /dev/xvdb2 120GB 100%
+      - /dev/{{ pnda_env['datanode']['DEVICE_ROOT'] }} msdos /dev/{{ pnda_env['datanode']['DEVICE_ROOT'] }}1 0GB 120GB
+      - /dev/{{ pnda_env['datanode']['DEVICE_ROOT'] }} msdos /dev/{{ pnda_env['datanode']['DEVICE_ROOT'] }}2 120GB 100%
 
   generic:
     volumes:

--- a/bootstrap-scripts/saltmaster-common.sh
+++ b/bootstrap-scripts/saltmaster-common.sh
@@ -223,4 +223,11 @@ dataset_compaction:
 EOF
 fi
 
+if [ "x$DATA_VOLUME_COUNT" != "x" ] ; then
+cat << EOF >> /srv/salt/platform-salt/pillar/env_parameters.sls
+datanode:
+  data_volume_count: $DATA_VOLUME_COUNT
+EOF
+fi
+
 /tmp/saltmaster-gen-keys.sh

--- a/bootstrap-scripts/standard/volume-config.yaml
+++ b/bootstrap-scripts/standard/volume-config.yaml
@@ -1,7 +1,13 @@
 classes:
   datanode:
     volumes:
-      - /data0 xfs
+{%- for n in range(pnda_env['datanode']['DATA_VOLUME_COUNT']) %}
+    {%- if pnda_env['datanode']['DATA_VOLUME_COUNT'] > 10 and n < 10 %}
+      - /data0{{ n }} xfs
+    {%- else %}
+      - /data{{ n }} xfs
+    {%- endif %}
+{%- endfor %}
       - /var/log/pnda xfs
 
   no_additonal_volumes:

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -219,3 +219,9 @@ dataset_compaction:
   # M - monthly compaction.
   # Y - yearly compaction.
   PATTERN: d
+
+datanode:
+  # DATANODE_VOLUME_COUNT sets the number of data volumes on each hadoop datanode
+  DATA_VOLUME_COUNT: 1
+  # DEVICE_ROOT sets the disk device root name
+  DEVICE_ROOT: xvdb


### PR DESCRIPTION
…l to allow multiple data drives to be used

Analysis:
The number of data volumes should be configurable in pnda_env.yaml to allow multiple data drives.

Solution:
Added DATA_VOLUME_COUNT in pnda-env.yaml file to specify the number of data volumes on each hadoop datanode.
Added DEVICE_ROOT in pnda-env.yaml file to specify disk device root name.
Introduced jinja processing to allow loop syntax in volume-config.yaml
Deployment specific definitions can be passed in volume-config.yaml.  pnda-cli will check for the number of data volumes present in volume-config.yaml.

Tested:
RHEL HDP
RHEL CDH