### PR TITLE
Require TLS on Knox if certificate is supplied

### DIFF
--- a/bootstrap-scripts/saltmaster-common.sh
+++ b/bootstrap-scripts/saltmaster-common.sh
@@ -84,7 +84,7 @@ if [ "x$SECURITY_CERTS_TARBALL" != "x" ]; then
     cert_file="/srv/salt/platform-salt/pillar/certs.sls"
     if [ -e cert_file ]; then rm cert_file; fi
     for i in `find /srv/security-certs/ -maxdepth 1 -mindepth 1 -type d -exec basename {} \;`; do
-      for j in `find /srv/security-certs/$i -maxdepth 1 -mindepth 1 -type f -name '*.pem'`; do
+      for j in `find /srv/security-certs/$i -maxdepth 1 -mindepth 1 -type f -name '*.crt'`; do
         echo -e "$i:\n  cert: |" >> $cert_file
         sed  's/^/    /' $j >> $cert_file
         break
@@ -99,7 +99,11 @@ if [ "x$SECURITY_CERTS_TARBALL" != "x" ]; then
         break;
       done;
     done;
-    #salt '*' saltutil.refresh_pillar
+    for i in `find /srv/security-certs/ -maxdepth 1 -mindepth 1 -type f -name '*.crt'`; do
+        echo -e "CA:\n  cert: |" >> $cert_file
+        sed  's/^/    /' $i >> $cert_file
+        break
+    done;
   fi
 fi
 
@@ -150,6 +154,11 @@ mine_functions:
 
 security:
   security: $SECURITY_MODE
+
+consul:
+  domain: $TOP_LEVEL_DOMAIN
+  data_center: $SECOND_LEVEL_DOMAIN
+
 EOF
 
 if [ "x$NTP_SERVERS" != "x" ] ; then

--- a/platform-certificates/README.md
+++ b/platform-certificates/README.md
@@ -1,0 +1,6 @@
+Security material put in this directory can be used to configure security on PNDA.
+It should either be left empty.
+Or it should include the private key and associated certificate (chain) needed to generate the security material for securing PNDA services.
+In the later case, it should contain:
+1. A file with a .crt extension and content in PEM format (Privacy-enhanced Electronic Mail): Base64 encoded DER certificate (chain) enclosed between "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----"
+2. A file with a .key extension and content in PEM format (Privacy-enhanced Electronic Mail): Base64 encoded DER key enclosed between "-----BEGIN ENCRYPTED PRIVATE KEY-----" and "-----END ENCRYPTED PRIVATE KEY-----"

--- a/platform-certificates/jupyter/README.md
+++ b/platform-certificates/jupyter/README.md
@@ -1,6 +1,0 @@
-Security material put in this directory can be used to configure jupyter.
-It should either be left empty to have jupyterhub accessible through http.
-Or it should include the private key and associated certificate chain needed to configure jupyterhub for SSL (https).
-In the later case, it should contain:
-1. A file with a .pem extension and content in PEM format (Privacy-enhanced Electronic Mail): Base64 encoded DER certificate chain (concatenation) with each certificate enclosed between "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----"
-2. A file with a .key extension and content in PEM format (Privacy-enhanced Electronic Mail): Base64 encoded DER key enclosed between "-----BEGIN ENCRYPTED PRIVATE KEY-----" and "-----END ENCRYPTED PRIVATE KEY-----"

--- a/platform-certificates/knox/README.md
+++ b/platform-certificates/knox/README.md
@@ -1,0 +1,6 @@
+Security material put in this directory can be used to configure knox.
+It should either be left empty to have knox accessible through http.
+Or it should include the private key and associated certificate needed to configure knox for SSL (https).
+In the later case, it should contain:
+1. A file with a .crt extension and content in PEM format (Privacy-enhanced Electronic Mail): Base64 encoded DER certificate enclosed between "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----"
+2. A file with a .key extension and content in PEM format (Privacy-enhanced Electronic Mail): Base64 encoded DER key enclosed between "-----BEGIN ENCRYPTED PRIVATE KEY-----" and "-----END ENCRYPTED PRIVATE KEY-----"

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -187,7 +187,7 @@ security:
   # - 'disabled': The security material will be ignored.  
   # - 'permissive': The security material will be used if present.
   # - 'enforced': The security material will be required to be present and conforment to the associated requirements.
-  SECURITY_MODE: 'permissive'
+  SECURITY_MODE: 'enforced'
 
   # The path were to find the security material (certificate/key).
   # The directory should be structured as defined in this' repo's directory structure with the same name.
@@ -199,6 +199,13 @@ features:
   # Include experimental features. 
   # Set to "NO", omit setting or omit features section entirely to turn off experimental features
   EXPERIMENTAL_FEATURES: "NO"
+
+domain:
+  # Top-level domain
+  TOP_LEVEL_DOMAIN: pnda.local
+
+  # Second-level domain
+  SECOND_LEVEL_DOMAIN: dc1
 
 dataset_compaction:
   # Enable/Disable compaction on datasets.


### PR DESCRIPTION
Adds TLS support for securing Knox.
Adds generation of a root ca key/cert pair and generation of services
key/cert pair when not present and SECURITY_MODE is set to 'enforced'
Changed the default setting the SECURITY_MODE='enforced'
Adds configuration for domain definition in pnda_env:
* Top-level domain
* Second-level domain

PNDA-4588