### PR TITLE
PNDA-4444: pnda-cli did not exit on error in pnda salt module function

### DIFF
--- a/cli/ssh_client.py
+++ b/cli/ssh_client.py
@@ -110,7 +110,9 @@ fi\n''')
         parts = cmd.split(' ')
         parts.append(' && '.join(cmds))
         CONSOLE.debug(json.dumps(parts))
-        ret_val = subprocess_to_log.call(parts, LOG, log_id=host, output=output, scan_for_errors=[r'lost connection', r'\s*Failed:\s*[1-9].*'])
+        ret_val = subprocess_to_log.call(parts, LOG, log_id=host, output=output, scan_for_errors=[r'lost connection',
+                                                                                                  r'\s*Failed:\s*[1-9].*',
+                                                                                                  r'\s*Failures:'])
         if ret_val != 0:
             raise Exception("Error running ssh commands on host %s. See debug log (%s) for details." % (host, LOG_FILE_NAME))
 

--- a/cli/subprocess_to_log.py
+++ b/cli/subprocess_to_log.py
@@ -20,11 +20,12 @@ def call(cmd_to_run, logger, log_id=None, stdout_log_level=INFO, stderr_log_leve
             msg = msg.decode('utf-8')
             if output is not None and child_output_stream == child_process.stdout:
                 output.append(msg)
+            original_msg = msg
             if log_id is not None:
                 msg = '%s %s' % (log_id, msg)
             logger.log(log_level[child_output_stream], msg)
             for pattern in scan_for_errors:
-                if re.match(pattern, msg):
+                if re.match(pattern, original_msg):
                     raise Exception(msg)
 
     while child_process.poll() is None:


### PR DESCRIPTION
Analysis: The log contains the error, but the cli did not pick this up and exit.
Solution: Extended set of things the cli looks to scan for the errors.
Files Modified: cli/ssh_client.py
Tested: RHEL HDP