### PR TITLE
Fix cmd2 at version compatible with python2

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,4 +1,5 @@
 boto==2.48.0
+cmd2==0.8.5
 PyYAML==3.12
 requests==2.14.2
 python-heatclient==1.14.0


### PR DESCRIPTION
cmd2 > 0.8.5 does not install because it requires python 3.

PNDA-4658