### PR TITLE
Remove internal services from pnda-cli

### DIFF
--- a/bootstrap-scripts/service_to_role.json
+++ b/bootstrap-scripts/service_to_role.json
@@ -1,7 +1,6 @@
 {
     "hadoop-manager": {"role": "hadoop_manager", "port": "8080"},
     "console-frontend": {"role": "console_frontend", "port": "80"},
-    "deployment-manager-internal": {"role": "deployment_manager", "port": "5000"},
     "package-repository": {"role": "package_repository", "port": "8888"},
     "data-service": {"role": "data_service", "port": "7000"},
     "jupyter": {"role": "jupyter", "port": "8000"},

--- a/cli/backend_base.py
+++ b/cli/backend_base.py
@@ -694,7 +694,7 @@ subjectAltName = @alt_names
             hosts_for_role = self._get_hosts_for_role(saltmaster_ip, role)
             # Get the addresses for those hosts
             def ip_for_service(name, props):
-                return 'private_ip_address' if name.endswith('-internal') or not props['ip_address'] else 'ip_address'
+                return 'private_ip_address' if not props['ip_address'] else 'ip_address'
             addresses_for_service = [instances[host][ip_for_service(service, instances[host])] for host in hosts_for_role]
             # Push records into registry mapping service->address
             affected_hosts.extend(hosts_for_role)


### PR DESCRIPTION
Do not setup internal service DNS records from the CLI. Services will register themselves for this purpose as external information is not required.

PNDA-4386