### PR TITLE
Allow subprocess_to_log to complete when an error is detected

### DIFF
--- a/cli/backend_base.py
+++ b/cli/backend_base.py
@@ -225,7 +225,9 @@ class BaseBackend(object):
         return platform_certs_tarball
 
     def _call(self, cmd):
-        subprocess_to_log.call(cmd.split(' '), LOG)
+        ret_val = subprocess_to_log.call(cmd.split(' '), LOG)
+        if ret_val != 0:
+            raise Exception("Error running %s" % cmd)
 
     def _ensure_certs(self):
         local_certs_path = self._pnda_env['security']['SECURITY_MATERIAL_PATH']

--- a/cli/ssh_client.py
+++ b/cli/ssh_client.py
@@ -101,6 +101,7 @@ fi\n''')
         cmd = "scp -F cli/ssh_config-%s %s %s:%s" % (self._cluster, ' '.join(files), host, '/tmp')
         CONSOLE.debug(cmd)
         ret_val = subprocess_to_log.call(cmd.split(' '), LOG, log_id=host)
+        CONSOLE.debug("scp result: %s", ret_val)
         if ret_val != 0:
             raise Exception("Error transferring files to new host %s via SCP. See debug log (%s) for details." % (host, LOG_FILE_NAME))
 
@@ -113,6 +114,7 @@ fi\n''')
         ret_val = subprocess_to_log.call(parts, LOG, log_id=host, output=output, scan_for_errors=[r'lost connection',
                                                                                                   r'\s*Failed:\s*[1-9].*',
                                                                                                   r'\s*Failures:'])
+        CONSOLE.debug("ssh result: %s", ret_val)
         if ret_val != 0:
             raise Exception("Error running ssh commands on host %s. See debug log (%s) for details." % (host, LOG_FILE_NAME))
 


### PR DESCRIPTION
subprocess_to_log can scan for errors in the command output. If an error is detected allow the command to complete to collect the logs which likely contain helpful diagnostic output rather than exiting straight away.

PNDA-4668