### PR TITLE
PNDA-4487 Make the user aware if they are trying to create PNDA with …

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -6,3 +6,5 @@ python-heatclient==1.14.0
 ruamel.yaml==0.15.37
 python-novaclient==3.3.0
 Jinja2==2.10
+bs4==0.0.1
+GitPython==2.1.10


### PR DESCRIPTION
…a set of misaligned versions(platform-salt, pnda-cli, components on the mirror)

Analysis
When the user starts to run the pnda-cli, should not proceed deployment if the platform-salt version and build version different.

Solution
compare the contents of service.sls with what's available on the mirror and refuse to continue if these versions are not available

Files Modified
cli/backend_base.py
cli/requirements.txt

Tested
RHEL-HDP
