### PR TITLE
PNDA-4105 Expand NTP server name to list of IPs

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -6,3 +6,4 @@ python-heatclient==1.14.0
 ruamel.yaml==0.15.37
 python-novaclient==3.3.0
 Jinja2==2.10
+dnspython==1.15.0


### PR DESCRIPTION
Analysis
Only one NTP server entry is currently supported, but this could resolve to multiple IPs. It's preferable to specify IPs as these don't require name resolution which can be problematic in some environments. Therefore, in case of NTP server names, expand to IPs, and use the list of IPs in SLS.

Solution
1. Introduced a method in cli/backend_base to get the list of IPs from NTP server name in deployment machine
2. Replaced the NTP_SERVERS value in self._pnda_env with the expanded IPs list.

Files Modified
 cli/backend_base.py
cli/requirements.txt

Tested
RHEL HDP
