### PR TITLE
PNDA-4578: Reverse proxy Jupyter & Grafana through gateway node

### DIFF
--- a/bootstrap-scripts/gateway.sh
+++ b/bootstrap-scripts/gateway.sh
@@ -13,4 +13,5 @@ set -e
 cat >> /etc/salt/grains <<EOF
 roles:
   - knox
+  - haproxy
 EOF

--- a/bootstrap-scripts/service_to_role.json
+++ b/bootstrap-scripts/service_to_role.json
@@ -8,5 +8,6 @@
     "kafka-manager": {"role": "kafka_manager", "port": "10900"},
     "logserver": {"role": "logserver", "port": "5601"},
     "opentsdb": {"role": "opentsdb", "port": "4242"},
-    "knox": {"role": "knox", "port": "8443"}
+    "knox": {"role": "knox", "port": "8443"},
+    "haproxy": {"role": "haproxy", "port": "8444"}
 }

--- a/platform-certificates/haproxy/README.md
+++ b/platform-certificates/haproxy/README.md
@@ -1,0 +1,10 @@
+Security material put in this directory can be used to configure haproxy.
+It should either be left empty to have haproxy accessible through http.
+Or it should include the private key, the associated certificate and fqdn needed to configure haproxy for SSL (https).
+In the later case, it should contain:
+1. A file with a .crt extension and content in PEM format (Privacy-enhanced Electronic Mail): Base64 encoded DER certificate enclosed between "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----"
+2. A file with a .key extension and content in PEM format (Privacy-enhanced Electronic Mail): Base64 encoded DER key enclosed between "-----BEGIN ENCRYPTED PRIVATE KEY-----" and "-----END ENCRYPTED PRIVATE KEY-----"
+3. A file with a .yaml extension and content in YAML format. The file should only contain one key and associated value. The key must be 'fqdn' and it's value should be a valid FQDN for the associated certificate. For example:
+   ```
+   fqdn: haproxy.service.dc1.pnda.local
+   ```


### PR DESCRIPTION
## Problem statements ##
PNDA 4578: Reverse proxy Jupyter & Grafana through gateway node

## Changes ##
- add haproxy role to gateway
- add haproxy as an external service
- add default certificate generation for haproxy service

## Tests ##
- CentOS/Pico