### PR TITLE
PNDA-4536 Kafka data dirs to be configurable in pnda_env.yaml

### DIFF
--- a/bootstrap-scripts/production/volume-config.yaml
+++ b/bootstrap-scripts/production/volume-config.yaml
@@ -15,6 +15,15 @@ classes:
       - /dev/{{ pnda_env['datanode']['DEVICE_ROOT'] }} msdos /dev/{{ pnda_env['datanode']['DEVICE_ROOT'] }}1 0GB 120GB
       - /dev/{{ pnda_env['datanode']['DEVICE_ROOT'] }} msdos /dev/{{ pnda_env['datanode']['DEVICE_ROOT'] }}2 120GB 100%
 
+  kafka:
+    volumes:
+      - /dev/{{ pnda_env['kafka']['KAFKA_DEVICE_ROOT'] }}2 /mnt xfs
+      - /dev/{{ pnda_env['kafka']['KAFKA_DEVICE_ROOT'] }}1 /var/log/pnda xfs
+      - tmpfs /tmp tmpfs nodev,nosuid
+    partitions:
+      - /dev/{{ pnda_env['kafka']['KAFKA_DEVICE_ROOT'] }} msdos /dev/{{ pnda_env['kafka']['KAFKA_DEVICE_ROOT'] }}1 0GB 120GB
+      - /dev/{{ pnda_env['kafka']['KAFKA_DEVICE_ROOT'] }} msdos /dev/{{ pnda_env['kafka']['KAFKA_DEVICE_ROOT'] }}2 120GB 100%
+
   generic:
     volumes:
       - /dev/xvdb2 /mnt xfs
@@ -34,7 +43,7 @@ instances:
   hadoop-mgr-2: generic
   hadoop-mgr-3: generic
   hadoop-mgr-4: generic
-  kafka: generic
+  kafka: kafka
   opentsdb: generic
   tools: generic
   zk: generic

--- a/bootstrap-scripts/saltmaster-common.sh
+++ b/bootstrap-scripts/saltmaster-common.sh
@@ -231,4 +231,11 @@ datanode:
 EOF
 fi
 
+if [ "x$KAFKA_DATA_DIRS" != "x" ] ; then
+cat << EOF >> /srv/salt/platform-salt/pillar/env_parameters.sls
+kafka:
+  data_dirs: $KAFKA_DATA_DIRS
+EOF
+fi
+
 /tmp/saltmaster-gen-keys.sh

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -233,3 +233,10 @@ datanode:
   DATA_VOLUME_COUNT: 1
   # DEVICE_ROOT sets the disk device root name
   DEVICE_ROOT: xvdb
+
+kafka:
+  # DATA_DIRS sets the data dirs on kafka node
+  KAFKA_DATA_DIRS:
+    - /var/kafka-logs
+  # DEVICE_ROOT sets the disk device root name
+  KAFKA_DEVICE_ROOT: xvdb


### PR DESCRIPTION
Analysis:
Kafka data dirs to be configurable in pnda_env.yaml

Solution:
Added DATA_DIRS setting in pnda-env.yaml to set the data_dirs in the pillar
Added DEVICE_ROOT setting in pnda-env.yaml to set the disks in the volume-config.yaml

Tested:
RHEL HDP PICO
RHEL HDP STANDARD
RHEL HDP PRODUCTION