### PR TITLE
PNDA-4055: Feature flags in YAML config not easily extensible

### DIFF
--- a/bootstrap-scripts/saltmaster-common.sh
+++ b/bootstrap-scripts/saltmaster-common.sh
@@ -202,11 +202,15 @@ package_repository:
 EOF
 fi
 
-if [ "x$EXPERIMENTAL_FEATURES" == "xYES" ] ; then
+if [ "x$FEATURES" != "x" ] ; then
 cat << EOF >> /srv/salt/platform-salt/pillar/env_parameters.sls
 features:
-  - EXPERIMENTAL
 EOF
+for feature in $FEATURES; do
+cat << EOF >> /srv/salt/platform-salt/pillar/env_parameters.sls
+  - $feature
+EOF
+done
 fi
 
 if [ "$COMPACTION" == "YES" ] ; then

--- a/cli/backend_base.py
+++ b/cli/backend_base.py
@@ -404,11 +404,16 @@ subjectAltName = @alt_names
         client_only = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'PLATFORM_GIT_BRANCH']
         with open('cli/pnda_env_%s.sh' % cluster, 'w') as pnda_env_sh_file:
             for section in self._pnda_env:
-                for setting in self._pnda_env[section]:
-                    if setting not in client_only:
-                        val = '"%s"' % self._pnda_env[section][setting] if isinstance(
-                            self._pnda_env[section][setting], (list, tuple)) else self._pnda_env[section][setting]
-                        pnda_env_sh_file.write('export %s=%s\n' % (setting, val))
+                if self._pnda_env[section] is not None:
+                    if isinstance(self._pnda_env[section], list):
+                        val = '"%s"' % " ".join(self._pnda_env[section])
+                        pnda_env_sh_file.write('export %s=%s\n' % (section.upper(), val))
+                    else:
+                        for setting in self._pnda_env[section]:
+                            if setting not in client_only:
+                                val = '"%s"' % self._pnda_env[section][setting] if isinstance(
+                                       self._pnda_env[section][setting], (list, tuple)) else self._pnda_env[section][setting]
+                                pnda_env_sh_file.write('export %s=%s\n' % (setting, val))
 
     def _bootstrap(self, instance, saltmaster, cluster, flavor, branch,
                    salt_tarball, certs_tarball, error_queue,

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -197,9 +197,15 @@ security:
   SECURITY_MATERIAL_PATH: ./platform-certificates/
 
 features:
-  # Include experimental features. 
-  # Set to "NO", omit setting or omit features section entirely to turn off experimental features
-  EXPERIMENTAL_FEATURES: "NO"
+  # Optional features can be enabled by including them in this list
+  # For example the following list will enable features F1, F2 and F3
+  # - F1
+  # - F2
+  # - F3
+  # Feature names should start with an alphabet and can contain alphabets and numerals (space is not allowed in feature name)
+  # use of special characters in feature names is not recommended, as it can cause conflict with YAML , JSON syntax
+  # Add SPARKMAGIC to features to include sparkmagic.
+  - SPARKMAGIC
 
 domain:
   # Top-level domain


### PR DESCRIPTION
# Problem Statement:
Dependency PR: https://github.com/pndaproject/platform-salt/pull/579
PNDA-4055: Feature flags in YAML config not easily extensible

# Changes:
- Updated pnda_env_example.yaml. Configured features as list of features instead of key-value pairs.
- Renamed EXPERIMENTAL to a specific optional feature name i.e SPARKMAGIC
- Updated backend_base.py to handle the list in the yaml file.
# Test details
RHEL(CDH pico and HDP pico)