### PR TITLE
Remove REJECT_OUTBOUND config

### DIFF
--- a/bootstrap-scripts/package-install.sh
+++ b/bootstrap-scripts/package-install.sh
@@ -2,7 +2,6 @@
 
 set -ex
 
-if [ "x$REJECT_OUTBOUND" == "xYES" ]; then
 PNDA_MIRROR_IP=$(echo $PNDA_MIRROR | awk -F'[/:]' '/http:\/\//{print $4}')
 
 # Log the global scope IP connection.
@@ -43,7 +42,6 @@ iptables -A LOGGING -j REJECT --reject-with icmp-net-unreachable
 iptables-save > /etc/iptables.conf
 echo -e '#!/bin/sh\niptables-restore < /etc/iptables.conf' > /etc/rc.local
 chmod +x /etc/rc.d/rc.local | true
-fi
 
 DISTRO=$(cat /etc/*-release|grep ^ID\=|awk -F\= {'print $2'}|sed s/\"//g)
 

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -185,7 +185,6 @@ ntp:
   # Optional ntp servers. Use this if the standard NTP servers on the Internet cannot be reached
   # and a local NTP server has been configured. PNDA will not work without NTP.
   # example format: 'xxx.ntp.org'
-  #For REJECT_OUTBOUND="YES" then NTP server/s must.
   NTP_SERVERS:
     - ntp.ubuntu.com
   # - 91.189.89.198
@@ -210,9 +209,7 @@ hadoop:
   OOZIE_SPARK_VERSION: 1
 
 connectivity:
-  # Deploy an iptables ruleset to every node preventing outbound access to all hosts except the PNDA_MIRROR, NTP_SERVER and specified CLIENT_IP. Specify YES to enable.
-  REJECT_OUTBOUND: "YES"
-  # If using REJECT_OUTBOUND, the IP address of the client that created PNDA
+  # The IP address of the client that created PNDA
   CLIENT_IP: 1.1.1.1
   # Add online repositories for yum, apt-get, pip, etc alongside PNDA mirror
   ADD_ONLINE_REPOS: "NO"


### PR DESCRIPTION
Remove REJECT_OUTBOUND config to force the pnda mirror to be used for all dependencies.

PNDA-4765