### PR TITLE
Validation file moved to common location

### DIFF
--- a/cli/validation.json
+++ b/cli/validation.json
@@ -1,0 +1,14 @@
+{
+  "pico":{
+    "zk-nodes":"0",
+    "kafka-nodes":"1",
+    "opentsdb-nodes":"0",
+    "datanodes":"1-3"
+  },
+  "standard":{
+    "zk-nodes":"1,3,5",
+    "kafka-nodes":"1-10",
+    "opentsdb-nodes":"1-20",
+    "datanodes":"1-20"
+  }
+}

--- a/cli/validation.py
+++ b/cli/validation.py
@@ -38,12 +38,12 @@ class RangeValidator(object):
         self._load(flavor)
 
     def _load(self, flavor):
-        path = '../cloud-formation/%s/validation.json' % flavor
+        path = './validation.json'
         if os.path.isfile(path):
             with open(path) as validation_file:
                 rules = json.load(validation_file)
                 # apply transformation applied by argparse so rules are addressable
-                for field, rule in rules.iteritems():
+                for field, rule in rules[flavor].iteritems():
                     self._rules[field.replace('-', '_')] = rule
 
     def _check_validation(self, restriction, value): #pylint: disable=R0911

--- a/cloud-formation/pico/validation.json
+++ b/cloud-formation/pico/validation.json
@@ -1,6 +1,0 @@
-{
-  "zk-nodes":"0",
-  "kafka-nodes":"1",
-  "opentsdb-nodes":"0",
-  "datanodes":"1-3"
-}

--- a/cloud-formation/standard/validation.json
+++ b/cloud-formation/standard/validation.json
@@ -1,6 +1,0 @@
-{
-  "zk-nodes":"1,3,5",
-  "kafka-nodes":"1-10",
-  "opentsdb-nodes":"1-20",
-  "datanodes":"1-20"
-}


### PR DESCRIPTION
Problem Statement:
PNDA-4815: PNDA CLI validation uses cloud formation validation files regardless of target

Analysis:
The validation.json file present in Cloudra-Formation(aws) directory regardless of target(aws, openstatck, terraform). 

Changes:
The validation.json file added in common place and modified the validation.json file to support pico & standard flavor types.

Test Details:
RHEL - PICO - HDP