### PR TITLE
Revert "Remove REJECT_OUTBOUND config"

### DIFF
--- a/bootstrap-scripts/package-install.sh
+++ b/bootstrap-scripts/package-install.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+if [ "x$REJECT_OUTBOUND" == "xYES" ]; then
 PNDA_MIRROR_IP=$(echo $PNDA_MIRROR | awk -F'[/:]' '/http:\/\//{print $4}')
 
 # Log the global scope IP connection.
@@ -42,6 +43,7 @@ iptables -A LOGGING -j REJECT --reject-with icmp-net-unreachable
 iptables-save > /etc/iptables.conf
 echo -e '#!/bin/sh\niptables-restore < /etc/iptables.conf' > /etc/rc.local
 chmod +x /etc/rc.d/rc.local | true
+fi
 
 DISTRO=$(cat /etc/*-release|grep ^ID\=|awk -F\= {'print $2'}|sed s/\"//g)
 

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -182,6 +182,7 @@ ntp:
   # Optional ntp servers. Use this if the standard NTP servers on the Internet cannot be reached
   # and a local NTP server has been configured. PNDA will not work without NTP.
   # example format: 'xxx.ntp.org'
+  #For REJECT_OUTBOUND="YES" then NTP server/s must.
   NTP_SERVERS:
     - ntp.ubuntu.com
   # - 91.189.89.198
@@ -212,7 +213,9 @@ hadoop:
   OOZIE_SPARK_VERSION: 1
 
 connectivity:
-  # The IP address of the client that created PNDA
+  # Deploy an iptables ruleset to every node preventing outbound access to all hosts except the PNDA_MIRROR, NTP_SERVER and specified CLIENT_IP. Specify YES to enable.
+  REJECT_OUTBOUND: "YES"
+  # If using REJECT_OUTBOUND, the IP address of the client that created PNDA
   CLIENT_IP: 1.1.1.1
   # Add online repositories for yum, apt-get, pip, etc alongside PNDA mirror
   ADD_ONLINE_REPOS: "NO"


### PR DESCRIPTION
This reverts pndaproject/pnda-cli#162

We've decided to continue to allow deployment without an iptables fw in place as an option for those users who understand the implications. 